### PR TITLE
locale: spelling fixes & other little tweaks

### DIFF
--- a/locale/en/config.cfg
+++ b/locale/en/config.cfg
@@ -39,15 +39,14 @@ fabricator-shuttle=Fabricator Shuttle
 landed-fabricator-shuttle=Landed Fabricator Shuttle
 ground-auto-fabricator=Ground Fabricator Station
 
-
 [item-description]
 space-lab=Components and supplies for the orbital stations.
-advanced-probe=An extremely expensive but highly rewarding deep-space probe. 
+advanced-probe=An extremely expensive but highly rewarding deep-space probe.
 observation-satellite=A combination of radar, GPS and communication satellites, provides data on the surface of the planet it orbits.
-space-telescope=With a powerful optic suite these satellites can see objects on the ground down to the centimeter or resolve astronomical objects lightyears away.
+space-telescope=With a powerful optic suite these satellites can see objects on the ground down to the centimeter or resolve astronomical objects light-years away.
 telescope-components=Expensive finely machined components necessary to seeing distant objects in detail.
 orbital-solar-collector=A satellite capable of producing 150 Megawatts of power for ground stations to receive.
-orbital-power-reciver=Collects up to 150mw of power from collection satellites in orbit.
+orbital-power-reciver=Collects up to 150MW of power from collection satellites in orbit.
 radioisotope-thermoelectric-generator=Heat produced by radioactive decay generates a small amount of electricity, this device can provide power to a satellite for decades far away from the sun. Just don't stand next to one for too long.
 satellite-battery=A battery purpose built for the rigors of space.
 satellite-bus=The core structure of any satellite.
@@ -55,7 +54,7 @@ satellite-communications=Space is big, we need powerful antennas to communicate 
 satellite-flight-computer=A complex computer purpose built to work in space for long durations and control satellites.
 satellite-radar=A redesigned radar array suitable for spacecraft.
 satellite-solar-array=Solar panels tailored for orbital life.
-satellite-thruster=Vacuum optimized external combustion engines. 
+satellite-thruster=Vacuum optimized external combustion engines.
 space-lab-payload=A payload to upgrade or service your orbital laboratories.
 landed-shuttle=A landed space shuttle, dirty from re-entry and loaded with science.
 shuttle-hull=An unfinished space shuttle, attach the engines, put your payload in and it is ready to go!
@@ -69,7 +68,7 @@ advanced-assembler=The height of automated crafting, this assembler can produce 
 autonomous-space-mining-drone=These drones will move independently of their host spacecraft and collect mineral ore from nearby asteroids. They also fabricate makeshift dropships to deliver the ore.
 copper-dropship=A crude vessel dropped from space loaded with copper ore.
 iron-dropship=A crude vessel dropped from space loaded with iron ore.
-landed-mining-shuttle=This vessel has collected all the ore it can and has returned home out of fuel. 
+landed-mining-shuttle=This vessel has collected all the ore it can and has returned home out of fuel.
 mining-shuttle=A rocket payload capable of returning a huge quantity of iron and copper ore.
 spy-shuttle=A modified space shuttle equipped with a high-resolution telescope suite.
 landed-spy-shuttle=This Telescope shuttle has completed is observation mission and exhausted its fuel. It can be refurbished and sent on another mission.
@@ -101,7 +100,7 @@ improved-space-program-theory=Improved Advanced Space Program Theory
 asteroid-mining=Asteroid Mining
 space-mining-theory=Space Mining Feasibility Study
 spy-shuttle=Space Telescope Shuttle
-shuttle-repurposing=Shuttle Repurposing
+shuttle-repurposing=Shuttle Re-purposing
 autonomous-space-mining-drones=Autonomous Space Mining Drones
 space-assembler-theory=Space Assembler Theory
 vacuum-smelting=Vacuum Smelting
@@ -114,34 +113,34 @@ orbital-ai-core=Orbital AI Data Core
 [technology-description]
 space-lab=Setting up laboratories in space could open up many different research possibilities.
 Space-Lab-Research=We can use our orbital laboratories to improve our research capabilities.
-station-science=Studying the data produced by orbital laboratories to improve research practices. 
+station-science=Studying the data produced by orbital laboratories to improve research practices.
 advanced-probe=There is plenty to learn by studying planets other than our own.
 observation-satellite=A combination of radar, GPS and communication satellites, provides data on the surface of the planet it orbits.
-robot-global-positioning-system=By knowing their exact locations drones can fly to their destinations much faster than before. More satellites will increase the accuracy of their location mapping. 
+robot-global-positioning-system=By knowing their exact locations drones can fly to their destinations much faster than before. More satellites will increase the accuracy of their location mapping.
 advanced-battery-research=Using our space laboratories we can now extensively test many materials under new conditions, improving the chemistry in our robot batteries.
-advanced-fan-research=Testing new blade and electrical engine designs in zero-g can provide us new insights into making our bots capable of lifting more. 
-extremely-advanced-material-processing=Better satellite components require incredibly precise machining processes. 
+advanced-fan-research=Testing new blade and electrical engine designs in zero-g can provide us new insights into making our bots capable of lifting more.
+extremely-advanced-material-processing=Better satellite components require incredibly precise machining processes.
 orbital-solar-collector=By sending up large solar power satellites into sun-synchronous orbits we can generate power from the sun without having to worry about nighttime or losing ground area to solar panels. Bouncing the power transmissions off other satellites means we get constant output to our ground stations.
 extremely-advanced-rocket-payloads=If we dedicate research time on some crazy ideas we might come up with something useful.
 space-shuttle=A large portion of the cost of our space station missions is in getting the cargo into space, creating a reusable payload stage will save large amounts of resources in the long run. However, the design and construction costs will be substantial.
 ground-telescope=With advanced enough optics we can study space without having to go there.
 advanced-machining=Our current machining tools aren't precise enough for advanced spacecraft components. we need entirely new facilities to produce this next generation of spacecraft.
 improved-space-program-theory=Our current rocket and satellite are undeniably effective yet leave much to be desired. If we dedicate some research time we could figure out how to better utilize the opportunities in space.
-asteroid-mining=There are trillions of tonnes of resources floating around in nearby asteroids. Our new mining drones working out of special shuttles will fabricate dropships filled with the ore they mine, when the shuttle gets low on fuel it will return with the dropships in pursuit. 
+asteroid-mining=There are trillions of tonnes of resources floating around in nearby asteroids. Our new mining drones working out of special shuttles will fabricate dropships filled with the ore they mine, when the shuttle gets low on fuel it will return with the dropships in pursuit.
 space-mining-theory=Our satellites have detected hundreds of thousands of large asteroids, we should study further and see if they could be useful.
 spy-shuttle=We can modify the space shuttle to house a powerful telescope in its cargo bay. These shuttles can preform special observation missions to produce telescope data.
 shuttle-repurposing=If space shuttles are to be the mainstay of our space program we will need some flexibility with our fleet. Reversing the final space shuttle assembly process will return us the basic shuttle hull and the components we put into the shuttle for its role.
-autonomous-space-mining-drones=To mine asteroids we need to develop an entirely new way of mining. One major obstacle is power production in such an environment; the debris from the mining process would destroy the solar panels on our drones. RTGs would work but we will need a lot of them. 
-space-assembler-theory=Establishing a large factory/rocket fuel refinery in the asteroid belt could massively increase our space mining capabilities, and the ore can be processed on site before being transported back. This will be a very expensive endeavor. 
+autonomous-space-mining-drones=To mine asteroids we need to develop an entirely new way of mining. One major obstacle is power production in such an environment; the debris from the mining process would destroy the solar panels on our drones. RTGs would work but we will need a lot of them.
+space-assembler-theory=Establishing a large factory/rocket fuel refinery in the asteroid belt could massively increase our space mining capabilities, and the ore can be processed on site before being transported back. This will be a very expensive endeavor.
 vacuum-smelting=Smelting ore is going to be problematic in a vacuum and without gravity our current designs won't work. We need to develop new methods.
 orbital-assembler-power-problem=In the asteroid belt solar panels are a waste of resources given all the debris and our proposed mining facilities will need far too much power for RTGs to work. Our best bet is to link the space fabricators into our own power grid through a ground station but this will require some serious research.
 orbital-autonomous-fabricators=These gigantic orbital structures will supply us with a near limitless amount of resources but at an extreme cost both in material and power.
 stack-inserter-research=While developing our space mining drones we accidentally stumbled across a line of research that could improve our stack inserters.
-space-telescope=Sending telescopes outside of the atmosphere we can drastically improve their capabilities and linking these telescopes to ground stations will enable continuous data production. They will be able to study astronomical objects and the surface of our planet. 
-orbital-artillery-rangefinding=Using our space telescopes and observation satellites we can pin down the exact locations of our enemies as well as studying atmospheric conditions, improving our artillery’s effective range. 
+space-telescope=Sending telescopes outside of the atmosphere we can drastically improve their capabilities and linking these telescopes to ground stations will enable continuous data production. They will be able to study astronomical objects and the surface of our planet.
+orbital-artillery-rangefinding=Using our space telescopes and observation satellites we can pin down the exact locations of our enemies as well as studying atmospheric conditions, improving our artillery’s effective range.
 space-telescope-research=Studying the nature of the universe around us will help our laboratories process data.
 orbital-prospecting=Advanced radar and optical sensors can improve our knowledge of ore patches and richness, making our mining processes more efficient.
-space-station-assembly=Our current scientific facilities in space are but a shadow of what they could be. By dedicating a large number of space lab launches to constructing an advanced station we could drastically improve our research capabilities. 
+space-station-assembly=Our current scientific facilities in space are but a shadow of what they could be. By dedicating a large number of space lab launches to constructing an advanced station we could drastically improve our research capabilities.
 orbital-ai-core=Space offers numerous advantages to computing systems and keeps them away from our enemies, if we create a large enough bank of computers it would be possible to set up a machine intelligence to run the everyday operations of our base like inserters, laser turrets and bots. This would be a massive improvement over our old software. What could possibly go wrong?
 
 [entity-name]
@@ -154,11 +153,11 @@ ground-auto-fabricator=Ground Fabricator Station
 
 [entity-description]
 orbital-power-reciver=Provides up to 150MW of energy from power producing satellites in orbit.
-shuttle-refurbishment-building=Where space shuttles are cleaned off, refued and have their science offloaded and new cargo put into the cargo bay.
-ground-telescope=Housing a powerful telescope this structure will study the sky continously producing space science even in daylight.
+shuttle-refurbishment-building=Where space shuttles are cleaned off, refueled, and have their science offloaded and new cargo put into the cargo bay.
+ground-telescope=Housing a powerful telescope this structure will study the sky continuously producing space science even in daylight.
 space-telescope-uplink-station=This satellite station will download data from orbiting space telescopes producing space science 5 times faster than ground stations.
-advanced-assembler=A powerful automated assembler capable of extrmely precise machining. 
-ground-auto-fabricator=This large structure contains the nessesary equipment to rapidly process the dropships from our orbital fabricators that land in its centeral pad. It also sends out the power nessesary for the orbital fabricator to work.
+advanced-assembler=A powerful automated assembler capable of extremely precise machining.
+ground-auto-fabricator=This large structure contains the necessary equipment to rapidly process the dropships from our orbital fabricators that land in its central pad. It also sends out the power necessary for the orbital fabricator to work.
 
 [recipe-name]
 space-study-the-stars=Space Telescope Study
@@ -190,5 +189,3 @@ study-the-planet=Study Planetary Surface
 
 [item-group-name]
 satellites=Satellites
-
- 


### PR DESCRIPTION
Several lines had trailing spaces; those have been removed, along with excess blank lines.

Resisted the urge to fix the entity name `orbital-power-reciver`, since that would definitely break things. :joy_cat: (I've never built a Factorio migration before, though, so I'd be glad to fix the name and make one.)